### PR TITLE
Add issue closer command

### DIFF
--- a/cmd/repo/issue.go
+++ b/cmd/repo/issue.go
@@ -1,0 +1,33 @@
+package repo
+
+import (
+	"github.com/chelnak/gh-iac/internal/issue"
+	"github.com/spf13/cobra"
+)
+
+var (
+	date  string
+	close bool
+	name  string
+)
+
+var issueCmd = &cobra.Command{
+	Use:   "issue [flags]",
+	Short: "Query for and optionally close issues for a given date.",
+	Long:  "Query for and optionally close issues for a given date.",
+	RunE: func(command *cobra.Command, args []string) error {
+		err := issue.CloseIssuesOlderThan(name, date, close)
+		if err != nil {
+			return err
+		}
+		return nil
+	},
+}
+
+func init() {
+	RepoRootCmd.AddCommand(issueCmd)
+
+	issueCmd.Flags().StringVarP(&name, "name", "n", "", "Name of the repository.")
+	issueCmd.Flags().StringVarP(&date, "date", "d", "2017-01-01", "Returns issues before the specified date. Date format: 'yyyy-MM-dd' (Default: '2017-01-01')")
+	issueCmd.Flags().BoolVarP(&close, "close", "c", false, "Closes issues returned by the query.")
+}

--- a/internal/issue/issue.go
+++ b/internal/issue/issue.go
@@ -1,0 +1,48 @@
+package issue
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cli/go-gh"
+	"github.com/google/go-github/v42/github"
+)
+
+func CloseIssuesOlderThan(repoName, date string, close bool) error {
+	ctx := context.Background()
+	repoOwner := "puppetlabs"
+
+	httpClient, err := gh.HTTPClient(nil)
+	if err != nil {
+		return err
+	}
+	client := github.NewClient(httpClient)
+
+	issues, _, err := client.Search.Issues(ctx, fmt.Sprintf("repo:%v/%v updated:<=%v type:issue state:open", repoOwner, repoName, date), &github.SearchOptions{ListOptions: github.ListOptions{PerPage: 100}})
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Total: %v\n", *issues.Total)
+	for i, iss := range issues.Issues {
+		fmt.Printf("Issue %v: %v - %v \n", i+1, *iss.Title, iss.UpdatedAt.Format("2006-01-02"))
+	}
+
+	if close {
+		for _, issue := range issues.Issues {
+			body := "Hello! We are doing some house keeping and noticed that this issue has been open for a long time.\n\nWe're going to close it but please do raise another issue if the issue still persists. 😄"
+			_, _, err := client.Issues.CreateComment(ctx, repoOwner, repoName, *issue.Number, &github.IssueComment{Body: &body})
+			if err != nil {
+				return err
+			}
+
+			_, _, err = client.Issues.Edit(ctx, repoOwner, repoName, *issue.Number, &github.IssueRequest{State: github.String("closed")})
+			if err != nil {
+				return err
+			}
+		}
+		fmt.Printf("%v issues closed in the %v repository", *issues.Total, repoName)
+	}
+
+	return nil
+}


### PR DESCRIPTION
This PR adds the issue closer command. This command is used for
closing issues before a certain date and adds a preset cordial comment
explaining that another issue should be raised if the problem still
persists.