### PR TITLE
Fix incorrect issue numbers

### DIFF
--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -62,6 +62,7 @@ func ListRepositorySettings() error {
 				PerPage: 100,
 			},
 		}
+
 		issues, _, err := g.Issues.ListByRepo(ctx, s[0], s[1], &listRepoOpts)
 		if err != nil {
 			return err
@@ -72,23 +73,27 @@ func ListRepositorySettings() error {
 				PerPage: 100,
 			},
 		}
+
 		prs, _, err := g.PullRequests.List(ctx, s[0], s[1], &listPROpts)
 		if err != nil {
 			return err
 		}
 
+		issueCount := len(issues)
+		prCount := len(prs)
+
 		row := []string{
 			module.Repo,
 			*entity.DefaultBranch,
-			strconv.FormatBool(*entity.HasIssues),
-			strconv.FormatBool(*entity.HasProjects),
-			strconv.FormatBool(*entity.HasWiki),
-			strconv.FormatBool(*entity.HasPages),
-			strconv.FormatBool(*entity.HasDownloads),
-			strconv.FormatBool(*entity.Archived),
+			strconv.FormatBool(entity.GetHasIssues()),
+			strconv.FormatBool(entity.GetHasProjects()),
+			strconv.FormatBool(entity.GetHasWiki()),
+			strconv.FormatBool(entity.GetHasPages()),
+			strconv.FormatBool(entity.GetHasDownloads()),
+			strconv.FormatBool(entity.GetArchived()),
 			strconv.FormatBool(entity.GetDeleteBranchOnMerge()),
-			strconv.Itoa(len(issues)),
-			strconv.Itoa(len(prs)),
+			strconv.Itoa(issueCount - prCount), // issues seems to be inclusive of issues and prs, so we need to subtract prs
+			strconv.Itoa(prCount),
 		}
 
 		data = append(data, row)


### PR DESCRIPTION
The issues response seems to be inclusive of PRs which gives us a result that represents `len(issues) + len(prs)`.

This commit addresses the issue by subtracting `len(prs)` from `len(issues)` to get the right number.

Note: I did attempt to use the search endpoint here, but was hitting rate limits fairly quickly.